### PR TITLE
Add profile update cooldowns and email verification

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -10,6 +10,7 @@ import AdminView from '../views/AdminView.vue'
 import LandingView from '../views/LandingView.vue'
 import AccountPersonalView from '../views/AccountPersonalView.vue'
 import AccountSecurityView from '../views/AccountSecurityView.vue'
+import VerifyEmailView from '../views/VerifyEmailView.vue'
 import AuthStore from '../scripts/authStore.js'
 import AboutView from '../views/AboutView.vue'
 
@@ -24,6 +25,7 @@ const router = createRouter({
     { path: '/register', component: Register, meta: { requiresAuth: false } },
     { path: '/forgot-password', component: ForgotPassword, meta: { requiresAuth: false } },
     { path: '/reset-password', component: ResetPassword, meta: { requiresAuth: false } },
+    { path: '/verify-email', component: VerifyEmailView, meta: { requiresAuth: false } },
     { path: '/teams', component: TeamsView, meta: { requiresAuth: true } },
     { path: '/teams/:teamId', component: TeamDetails, meta: { requiresAuth: true } },
     { path: '/about', component: AboutView, meta: { requiresAuth: true } },

--- a/client/src/views/AccountPersonalView.vue
+++ b/client/src/views/AccountPersonalView.vue
@@ -28,7 +28,17 @@
               </v-avatar>
             </div>
             <div class="profile-info">
-              <h3>{{ user.username }}</h3>
+              <div class="profile-title">
+                <h3>{{ user.username }}</h3>
+                <span v-if="user.pendingEmail" class="status-chip warning">
+                  <v-icon size="16">mdi-clock-outline</v-icon>
+                  Verification pending
+                </span>
+                <span v-else class="status-chip success">
+                  <v-icon size="16">mdi-check-circle</v-icon>
+                  All set
+                </span>
+              </div>
               <p class="email">{{ user.email }}</p>
               <p class="user-id">User ID: {{ user.userId }}</p>
             </div>
@@ -43,7 +53,18 @@
               </div>
               <div class="info-item">
                 <label>Email Address</label>
-                <div class="info-value">{{ maskedEmail }}</div>
+                <div class="info-value">
+                  {{ user.email }}
+                  <span v-if="!user.pendingEmail" class="status-chip success subtle">Verified</span>
+                  <span v-else class="status-chip warning subtle">Current</span>
+                </div>
+              </div>
+              <div class="info-item" v-if="user.pendingEmail">
+                <label>Pending Email</label>
+                <div class="info-value pending">
+                  {{ user.pendingEmail }}
+                  <span class="status-chip warning subtle">Verification required</span>
+                </div>
               </div>
               <div class="info-item">
                 <label>Account ID</label>
@@ -54,6 +75,25 @@
                 <div class="info-value">{{ memberSince }}</div>
               </div>
             </div>
+            <div v-if="user.pendingEmail" class="pending-email-banner">
+              <v-icon size="18">mdi-email-clock</v-icon>
+              <span>
+                We've sent a confirmation email to <strong>{{ user.pendingEmail }}</strong>.
+                <span v-if="emailVerificationDeadlineText">
+                  Please verify by {{ emailVerificationDeadlineText }}.
+                </span>
+              </span>
+            </div>
+            <ul class="cooldown-list">
+              <li v-if="usernameCooldownText">
+                <v-icon size="18">mdi-calendar-clock</v-icon>
+                <span>Next display name update available {{ usernameCooldownText }}</span>
+              </li>
+              <li v-if="emailCooldownText">
+                <v-icon size="18">mdi-email-sync-outline</v-icon>
+                <span>Next email update available {{ emailCooldownText }}</span>
+              </li>
+            </ul>
           </div>
 
           <div class="profile-actions">
@@ -117,35 +157,130 @@
             <v-icon>mdi-close</v-icon>
           </button>
         </div>
-        <div class="popup-content">
-          <form @submit.prevent="saveProfile" class="profile-form">
-            <div class="form-group">
-              <label for="editUsername">Username</label>
-              <input
-                id="editUsername"
-                v-model="editForm.username"
-                type="text"
-                class="form-input"
-                required
-              />
-            </div>
-            <div class="form-group">
-              <label for="editEmail">Email Address</label>
-              <input
-                id="editEmail"
-                v-model="editForm.email"
-                type="email"
-                class="form-input"
-                required
-              />
+        <div class="popup-content epic-edit-container">
+          <form @submit.prevent="saveProfile" class="profile-form epic-form">
+            <section class="epic-section">
+              <div class="section-header">
+                <div class="section-icon">
+                  <v-icon>mdi-account-edit</v-icon>
+                </div>
+                <div>
+                  <h4>Update your display name</h4>
+                  <p>
+                    Choose a display name that represents you. Once confirmed, you'll need to wait two
+                    weeks to change it again.
+                  </p>
+                </div>
+              </div>
+              <div class="epic-body">
+                <div class="epic-field">
+                  <label class="field-label" for="editUsername">New display name</label>
+                  <div class="input-shell">
+                    <v-icon class="field-icon" size="20">mdi-account-outline</v-icon>
+                    <input
+                      id="editUsername"
+                      v-model="editForm.username"
+                      type="text"
+                      class="form-input"
+                      placeholder="Enter new display name"
+                      required
+                    />
+                  </div>
+                  <p class="field-helper">
+                    Never use personal information such as your real name, address, or phone number.
+                  </p>
+                </div>
+                <ul class="epic-guidelines">
+                  <li>
+                    <v-icon size="16">mdi-form-textbox</v-icon>
+                    Display names must be at least 3 characters long.
+                  </li>
+                  <li>
+                    <v-icon size="16">mdi-timer-lock-outline</v-icon>
+                    You won't be able to change your display name again for two weeks.
+                  </li>
+                </ul>
+                <label v-if="requiresUsernameAcknowledgement" class="epic-checkbox">
+                  <input type="checkbox" v-model="acknowledgements.username" />
+                  <span>
+                    I understand I can't change my display name again for 2 weeks after this change.
+                  </span>
+                </label>
+              </div>
+            </section>
+
+            <section class="epic-section">
+              <div class="section-header">
+                <div class="section-icon accent">
+                  <v-icon>mdi-email-edit-outline</v-icon>
+                </div>
+                <div>
+                  <h4>Update your email</h4>
+                  <p>
+                    We'll send a verification link to your new address. You won't be able to update it
+                    again for 90 days after verification.
+                  </p>
+                </div>
+              </div>
+              <div class="epic-body">
+                <div class="epic-field">
+                  <label class="field-label" for="editEmail">New email address</label>
+                  <div class="input-shell">
+                    <v-icon class="field-icon" size="20">mdi-email-outline</v-icon>
+                    <input
+                      id="editEmail"
+                      v-model="editForm.email"
+                      type="email"
+                      class="form-input"
+                      placeholder="name@example.com"
+                      required
+                    />
+                  </div>
+                  <p class="field-helper">
+                    We'll send a verification message to confirm this change before it's applied.
+                  </p>
+                </div>
+                <div v-if="user.pendingEmail" class="pending-note">
+                  <v-icon size="18">mdi-email-clock-outline</v-icon>
+                  <span>
+                    A verification email is waiting at <strong>{{ user.pendingEmail }}</strong>.
+                    <span v-if="emailVerificationDeadlineText">
+                      Please verify by {{ emailVerificationDeadlineText }}.
+                    </span>
+                  </span>
+                </div>
+                <ul class="epic-guidelines">
+                  <li>
+                    <v-icon size="16">mdi-shield-check</v-icon>
+                    You'll need to verify the new email before it replaces your current one.
+                  </li>
+                  <li>
+                    <v-icon size="16">mdi-timer-sand</v-icon>
+                    After verification, you can't change your email again for 90 days.
+                  </li>
+                </ul>
+                <label v-if="requiresEmailAcknowledgement" class="epic-checkbox">
+                  <input type="checkbox" v-model="acknowledgements.email" />
+                  <span>
+                    I understand my email can't be changed again for 90 days after verification.
+                  </span>
+                </label>
+              </div>
+            </section>
+
+            <div class="popup-actions inline-actions">
+              <button type="button" class="popup-button secondary" @click="closeEditProfile">
+                Cancel
+              </button>
+              <button
+                type="submit"
+                class="popup-button primary"
+                :disabled="isSaving || !canSaveProfile"
+              >
+                {{ isSaving ? 'Saving...' : 'Save Changes' }}
+              </button>
             </div>
           </form>
-        </div>
-        <div class="popup-actions">
-          <button class="popup-button secondary" @click="closeEditProfile">Cancel</button>
-          <button class="popup-button primary" @click="saveProfile" :disabled="isSaving">
-            {{ isSaving ? 'Saving...' : 'Save Changes' }}
-          </button>
         </div>
       </div>
     </div>
@@ -208,6 +343,11 @@ export default {
         userId: '',
         username: '',
         email: '',
+        pendingEmail: null,
+        emailVerified: true,
+        lastUsernameChangeAt: null,
+        lastEmailChangeAt: null,
+        emailVerificationExpires: null,
       },
       message: null,
       messageTimeout: null,
@@ -218,22 +358,102 @@ export default {
         username: '',
         email: '',
       },
+      acknowledgements: {
+        username: false,
+        email: false,
+      },
       deleteConfirmation: '',
       isSaving: false,
       isDeleting: false,
     }
   },
   computed: {
-    maskedEmail() {
-      if (!this.user.email) return ''
-      const [username, domain] = this.user.email.split('@')
-      if (username.length <= 2) return this.user.email
-      const maskedUsername =
-        username[0] + '*'.repeat(username.length - 2) + username[username.length - 1]
-      return `${maskedUsername}@${domain}`
-    },
     memberSince() {
       return 'January 2024'
+    },
+    requiresUsernameAcknowledgement() {
+      const currentUsername = this.user.username?.toLowerCase() || ''
+      const newUsername = this.editForm.username?.trim().toLowerCase() || ''
+      return newUsername && newUsername !== currentUsername
+    },
+    pendingEmailMatchesInput() {
+      if (!this.user.pendingEmail) return false
+      return (
+        this.editForm.email?.trim().toLowerCase() === this.user.pendingEmail.toLowerCase()
+      )
+    },
+    requiresEmailAcknowledgement() {
+      const currentEmail = this.user.email?.toLowerCase() || ''
+      const newEmail = this.editForm.email?.trim().toLowerCase() || ''
+      if (!newEmail || newEmail === currentEmail) {
+        return false
+      }
+      if (this.pendingEmailMatchesInput) {
+        return false
+      }
+      return true
+    },
+    canSaveProfile() {
+      const newUsername = this.editForm.username?.trim().toLowerCase() || ''
+      const currentUsername = this.user.username?.toLowerCase() || ''
+      const newEmail = this.editForm.email?.trim().toLowerCase() || ''
+      const currentEmail = this.user.email?.toLowerCase() || ''
+
+      const usernameChanged = newUsername && newUsername !== currentUsername
+      const emailChanged = newEmail && newEmail !== currentEmail
+      const reissueVerification = this.pendingEmailMatchesInput
+
+      if (!usernameChanged && !emailChanged && !reissueVerification) {
+        return false
+      }
+
+      if (this.requiresUsernameAcknowledgement && !this.acknowledgements.username) {
+        return false
+      }
+
+      if (this.requiresEmailAcknowledgement && !this.acknowledgements.email) {
+        return false
+      }
+
+      return true
+    },
+    usernameLockDeadline() {
+      if (!this.user.lastUsernameChangeAt) return null
+      const deadline = new Date(this.user.lastUsernameChangeAt)
+      if (Number.isNaN(deadline.getTime())) return null
+      deadline.setTime(deadline.getTime() + 14 * 24 * 60 * 60 * 1000)
+      return deadline > new Date() ? deadline : null
+    },
+    emailLockDeadline() {
+      if (!this.user.lastEmailChangeAt) return null
+      const deadline = new Date(this.user.lastEmailChangeAt)
+      if (Number.isNaN(deadline.getTime())) return null
+      deadline.setTime(deadline.getTime() + 90 * 24 * 60 * 60 * 1000)
+      return deadline > new Date() ? deadline : null
+    },
+    emailVerificationDeadline() {
+      if (!this.user.emailVerificationExpires) return null
+      const deadline = new Date(this.user.emailVerificationExpires)
+      if (Number.isNaN(deadline.getTime())) return null
+      return deadline
+    },
+    usernameCooldownText() {
+      const deadline = this.usernameLockDeadline
+      if (!deadline) return ''
+      const formatted = this.formatDateTime(deadline)
+      return formatted ? `on ${formatted}` : ''
+    },
+    emailCooldownText() {
+      const deadline = this.emailLockDeadline
+      if (!deadline) return ''
+      const formatted = this.formatDateTime(deadline)
+      return formatted ? `on ${formatted}` : ''
+    },
+    emailVerificationDeadlineText() {
+      const deadline = this.emailVerificationDeadline
+      if (!deadline) return ''
+      const formatted = this.formatDateTime(deadline)
+      return formatted ? `by ${formatted}` : ''
     },
   },
   async mounted() {
@@ -245,15 +465,40 @@ export default {
     }
   },
   methods: {
+    formatDateTime(dateInput) {
+      if (!dateInput) return ''
+      const date = new Date(dateInput)
+      if (Number.isNaN(date.getTime())) return ''
+      return date.toLocaleString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    },
+
+    setUserFromResponse(userData) {
+      if (!userData) return
+
+      this.user = {
+        userId: userData.userId ? userData.userId.toString() : '',
+        username: userData.username || '',
+        email: userData.email || '',
+        pendingEmail: userData.pendingEmail || null,
+        emailVerified: userData.emailVerified !== false,
+        lastUsernameChangeAt: userData.lastUsernameChangeAt || null,
+        lastEmailChangeAt: userData.lastEmailChangeAt || null,
+        emailVerificationExpires: userData.emailVerificationExpires || null,
+      }
+    },
+
     async loadUserData() {
       try {
         const userData = await AuthStore.getUserByAccessToken()
         if (userData) {
-          this.user = {
-            userId: userData.userId,
-            username: userData.username,
-            email: userData.email,
-          }
+          this.setUserFromResponse(userData)
         }
       } catch (error) {
         console.error('Error loading user data:', error)
@@ -262,37 +507,43 @@ export default {
 
     openEditProfile() {
       this.editForm.username = this.user.username
-      this.editForm.email = this.user.email
+      this.editForm.email = this.user.pendingEmail || this.user.email
+      this.resetAcknowledgements()
       this.showEditProfilePopup = true
     },
 
     closeEditProfile() {
       this.showEditProfilePopup = false
-      this.editForm = {
-        username: '',
-        email: '',
-      }
+      this.resetEditForm()
     },
 
     async saveProfile() {
+      if (!this.canSaveProfile) {
+        return
+      }
+
       this.isSaving = true
       try {
         const PORT = import.meta.env.VITE_API_PORT
+        const payload = {
+          username: this.editForm.username.trim(),
+          email: this.editForm.email.trim(),
+        }
         const response = await fetch(`${PORT}/api/users/profile`, {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
           },
           credentials: 'include',
-          body: JSON.stringify({
-            username: this.editForm.username,
-            email: this.editForm.email,
-          }),
+          body: JSON.stringify(payload),
         })
 
+        const data = await response.json().catch(() => ({}))
+
         if (response.ok) {
-          this.user.username = this.editForm.username
-          this.user.email = this.editForm.email
+          if (data.user) {
+            this.setUserFromResponse(data.user)
+          }
 
           localStorage.setItem(
             'currentUser',
@@ -304,10 +555,18 @@ export default {
           )
 
           this.closeEditProfile()
-          this.showMessage('Profile updated successfully!', 'success')
+
+          const messageText = data.message || 'Profile updated successfully!'
+          this.showMessage(messageText, data.requiresEmailVerification ? 'info' : 'success')
         } else {
-          const data = await response.json()
-          this.showMessage(data.error || 'Failed to update profile', 'error')
+          let errorMessage = data.error || data.message || 'Failed to update profile'
+          if (data.availableAt) {
+            const formatted = this.formatDateTime(data.availableAt)
+            if (formatted) {
+              errorMessage = `${errorMessage} Next update available on ${formatted}.`
+            }
+          }
+          this.showMessage(errorMessage, 'error')
         }
       } catch (error) {
         console.error('Error updating profile:', error)
@@ -315,6 +574,17 @@ export default {
       } finally {
         this.isSaving = false
       }
+    },
+
+    resetEditForm() {
+      this.editForm.username = ''
+      this.editForm.email = ''
+      this.resetAcknowledgements()
+    },
+
+    resetAcknowledgements() {
+      this.acknowledgements.username = false
+      this.acknowledgements.email = false
     },
 
     openDeleteAccount() {
@@ -512,7 +782,14 @@ export default {
   border-bottom: 1px solid #eee;
 }
 
-.profile-info h3 {
+.profile-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.profile-title h3 {
   margin: 0 0 8px 0;
   color: #333;
   font-size: 24px;
@@ -528,6 +805,36 @@ export default {
   color: #999;
   margin: 0;
   font-size: 14px;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.status-chip :deep(.v-icon) {
+  font-size: 16px;
+}
+
+.status-chip.success {
+  background: #e6f4ea;
+  color: #156a33;
+}
+
+.status-chip.warning {
+  background: #fff4d5;
+  color: #8b6500;
+}
+
+.status-chip.subtle {
+  padding: 2px 8px;
+  font-size: 11px;
 }
 
 .profile-details {
@@ -558,6 +865,56 @@ export default {
   color: #333;
   font-size: 16px;
   padding: 8px 0;
+}
+
+.info-value.pending {
+  color: #1d3a8a;
+}
+
+.pending-email-banner {
+  margin-top: 16px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: 14px;
+  border: 1px solid #dbe5ff;
+  background: linear-gradient(135deg, #f8faff, #eef3ff);
+  color: #1d3a8a;
+  font-size: 14px;
+}
+
+.pending-email-banner strong {
+  color: #0d47a1;
+}
+
+.pending-email-banner :deep(.v-icon) {
+  color: #4a90e2;
+  margin-top: 2px;
+}
+
+.cooldown-list {
+  list-style: none;
+  padding: 0;
+  margin: 20px 0 0;
+  display: grid;
+  gap: 12px;
+}
+
+.cooldown-list li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: #f7f8fb;
+  border: 1px solid #e6e9f2;
+  color: #4a4d57;
+  font-size: 14px;
+}
+
+.cooldown-list :deep(.v-icon) {
+  color: #4a90e2;
 }
 
 .profile-actions h4 {
@@ -841,6 +1198,200 @@ export default {
   border-color: #4a90e2;
 }
 
+.epic-edit-container {
+  background: #f4f6fb;
+  padding: 24px;
+}
+
+.epic-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  text-align: left;
+}
+
+.epic-section {
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid #e6e9f2;
+  padding: 24px 24px 28px;
+  box-shadow: 0 12px 32px rgba(27, 39, 94, 0.08);
+}
+
+.section-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.section-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #4a90e2, #7ba8ff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.section-icon.accent {
+  background: linear-gradient(135deg, #9352ff, #6a57ff);
+}
+
+.section-header h4 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  color: #1f2937;
+}
+
+.section-header p {
+  margin: 0;
+  color: #6b7280;
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.epic-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.epic-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field-label {
+  font-weight: 600;
+  color: #1f2937;
+  font-size: 14px;
+}
+
+.input-shell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #f9f9fc;
+  border: 1px solid #d9dce6;
+  border-radius: 14px;
+  padding: 0 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.input-shell:focus-within {
+  border-color: #4a90e2;
+  box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.15);
+  background: #ffffff;
+}
+
+.input-shell .form-input {
+  border: none;
+  background: transparent;
+  padding: 14px 0;
+  font-size: 15px;
+  color: #111827;
+}
+
+.input-shell .form-input:focus {
+  border: none;
+}
+
+.field-icon {
+  color: #4a90e2;
+}
+
+.field-helper {
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.epic-guidelines {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.epic-guidelines li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: #f4f6fb;
+  color: #4a4d57;
+  font-size: 13px;
+}
+
+.epic-guidelines :deep(.v-icon) {
+  color: #4a90e2;
+}
+
+.epic-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid #f7e4c2;
+  background: #fdf6e9;
+  font-size: 13px;
+  color: #5a4822;
+}
+
+.epic-checkbox input {
+  margin-top: 4px;
+  width: 18px;
+  height: 18px;
+  accent-color: #4a90e2;
+}
+
+.epic-checkbox span {
+  line-height: 1.4;
+}
+
+.pending-note {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #d8e2ff;
+  background: #f3f6ff;
+  color: #203a95;
+  font-size: 13px;
+}
+
+.pending-note strong {
+  color: #0b2fa2;
+}
+
+.pending-note :deep(.v-icon) {
+  color: #4a90e2;
+  margin-top: 2px;
+}
+
+.inline-actions {
+  background: transparent;
+  border-top: 1px solid #e6e9f2;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 18px 0 0;
+  text-align: right;
+}
+
+.inline-actions .popup-button.secondary {
+  margin-right: 0;
+}
+
 .popup-message.danger {
   color: #dc3545;
   font-weight: 600;
@@ -879,6 +1430,24 @@ export default {
   .info-grid,
   .actions-grid {
     grid-template-columns: 1fr;
+  }
+
+  .epic-section {
+    padding: 20px;
+  }
+
+  .section-header {
+    flex-direction: column;
+  }
+
+  .inline-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .inline-actions .popup-button {
+    width: 100%;
   }
 
   .tab-navigation {

--- a/client/src/views/VerifyEmailView.vue
+++ b/client/src/views/VerifyEmailView.vue
@@ -1,0 +1,264 @@
+<template>
+  <div class="verify-email">
+    <div class="verify-card" :class="status">
+      <div v-if="loading" class="verify-loading">
+        <v-progress-circular indeterminate color="primary" size="40"></v-progress-circular>
+        <p>Verifying your email address...</p>
+      </div>
+      <template v-else>
+        <div class="icon-wrapper" :class="status">
+          <v-icon :color="iconColor" size="48">{{ statusIcon }}</v-icon>
+        </div>
+        <h2>{{ title }}</h2>
+        <p class="message">{{ message }}</p>
+        <p v-if="details" class="details">{{ details }}</p>
+        <div class="actions">
+          <button v-if="status === 'success'" class="action primary" @click="goToLogin">
+            Sign in
+          </button>
+          <button v-if="status !== 'pending'" class="action secondary" @click="goToAccount">
+            Back to account
+          </button>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'VerifyEmailView',
+  data() {
+    return {
+      loading: true,
+      status: 'pending',
+      message: '',
+      details: '',
+    }
+  },
+  computed: {
+    title() {
+      if (this.loading) return 'Verifying email'
+      if (this.status === 'success') return 'Email verified'
+      if (this.status === 'error') return 'Verification failed'
+      return 'Verification status'
+    },
+    statusIcon() {
+      if (this.loading) return 'mdi-email-sync'
+      if (this.status === 'success') return 'mdi-check-circle'
+      if (this.status === 'error') return 'mdi-alert-circle'
+      return 'mdi-email-sync-outline'
+    },
+    iconColor() {
+      if (this.status === 'success') return 'success'
+      if (this.status === 'error') return 'error'
+      return 'primary'
+    },
+  },
+  async mounted() {
+    await this.verifyEmail()
+  },
+  methods: {
+    formatDateTime(dateInput) {
+      if (!dateInput) return ''
+      const date = new Date(dateInput)
+      if (Number.isNaN(date.getTime())) return ''
+      return date.toLocaleString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    },
+    async verifyEmail() {
+      const token = this.$route.query.token
+      if (!token) {
+        this.loading = false
+        this.status = 'error'
+        this.message = 'Verification token is missing. Please use the link from your email.'
+        return
+      }
+
+      try {
+        const PORT = import.meta.env.VITE_API_PORT
+        const response = await fetch(`${PORT}/api/users/email/verify`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify({ token }),
+        })
+
+        const data = await response.json().catch(() => ({}))
+
+        if (response.ok) {
+          this.status = 'success'
+          this.message = data.success || 'Your email has been verified successfully.'
+          if (data.emailCooldownEndsAt) {
+            const formatted = this.formatDateTime(data.emailCooldownEndsAt)
+            if (formatted) {
+              this.details = `You can update your email address again on ${formatted}.`
+            }
+          } else {
+            this.details = 'For security, you will need to sign in again to continue.'
+          }
+        } else {
+          this.status = 'error'
+          this.message = data.error || 'We could not verify your email. The link may have expired.'
+          if (data.message && data.message !== data.error) {
+            this.details = data.message
+          }
+        }
+      } catch (error) {
+        console.error('Error verifying email:', error)
+        this.status = 'error'
+        this.message = 'Something went wrong while verifying your email. Please try again.'
+      } finally {
+        this.loading = false
+      }
+    },
+    goToLogin() {
+      this.$router.push('/login')
+    },
+    goToAccount() {
+      this.$router.push('/account/personal')
+    },
+  },
+}
+</script>
+
+<style scoped>
+.verify-email {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f4f7ff, #ffffff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 16px;
+}
+
+.verify-card {
+  width: 100%;
+  max-width: 460px;
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 36px 32px;
+  box-shadow: 0 24px 60px rgba(20, 32, 84, 0.15);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.verify-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  color: #1f2937;
+  font-size: 16px;
+}
+
+.icon-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 20px;
+  margin: 0 auto;
+}
+
+.icon-wrapper.success {
+  background: #e6f4ea;
+}
+
+.icon-wrapper.error {
+  background: #fdecea;
+}
+
+.icon-wrapper.pending {
+  background: #eef2ff;
+}
+
+h2 {
+  margin: 0;
+  font-size: 26px;
+  color: #1f2937;
+}
+
+.message {
+  margin: 0;
+  color: #374151;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.details {
+  margin: 0;
+  color: #6b7280;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.action {
+  padding: 12px 24px;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action.primary {
+  background: #4a90e2;
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(74, 144, 226, 0.25);
+}
+
+.action.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(74, 144, 226, 0.3);
+}
+
+.action.secondary {
+  background: #eef1f7;
+  color: #1f2937;
+}
+
+.action.secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(30, 41, 59, 0.12);
+}
+
+@media (max-width: 600px) {
+  .verify-card {
+    padding: 28px 24px;
+    border-radius: 20px;
+  }
+
+  h2 {
+    font-size: 22px;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+
+  .action {
+    width: 100%;
+  }
+}
+</style>

--- a/server/models/Account.js
+++ b/server/models/Account.js
@@ -18,6 +18,10 @@ const accountSchema = new mongoose.Schema({
       message: (props) => `${props.value} is not a valid email!`,
     },
   },
+  emailVerified: {
+    type: Boolean,
+    default: true,
+  },
   password: {
     type: String,
   },
@@ -25,6 +29,25 @@ const accountSchema = new mongoose.Schema({
     type: String,
     enum: ['local', 'google'],
     required: true,
+  },
+  lastUsernameChangeAt: {
+    type: Date,
+    default: null,
+  },
+  lastEmailChangeAt: {
+    type: Date,
+    default: null,
+  },
+  pendingEmail: {
+    type: String,
+    lowercase: true,
+    default: null,
+  },
+  emailVerificationToken: {
+    type: String,
+  },
+  emailVerificationExpires: {
+    type: Date,
   },
   passwordResetToken: {
     type: String,

--- a/server/routes/users_routes.js
+++ b/server/routes/users_routes.js
@@ -1,16 +1,18 @@
 import express from 'express'
 import { authenticateAccessToken } from '../verify/JWTAuth.js'
-import { getAllUsers, updateUserProfile, deleteUserAccount } from './users.js'
+import {
+  getAuthenticatedUser,
+  getAllUsers,
+  updateUserProfile,
+  deleteUserAccount,
+  verifyEmailChange,
+} from './users.js'
 const router = express.Router()
 
-router.get('/', authenticateAccessToken, (req, res) => {
-  res.status(200).json({
-    user: req.user,
-    success: 'User data retrieved successfully',
-  })
-})
+router.get('/', authenticateAccessToken, getAuthenticatedUser)
 router.get('/all', authenticateAccessToken, getAllUsers)
 router.put('/profile', authenticateAccessToken, updateUserProfile)
 router.delete('/account', authenticateAccessToken, deleteUserAccount)
+router.post('/email/verify', verifyEmailChange)
 
 export default router


### PR DESCRIPTION
## Summary
- extend the account schema with timestamps and verification state used to enforce username and email change cooldowns and pending verification tokens
- overhaul the profile update backend to guard against frequent changes, trigger verification emails, expose a verification endpoint, and return richer account metadata
- restyle the account settings edit dialog with Epic-inspired UI, acknowledgements, and cooldown messaging while surfacing pending email status and integrate a new verify-email view and route

## Testing
- ⚠️ `bun run lint` *(fails: Cannot find package 'eslint' imported from /workspace/TM-Project/eslint.config.js)*


------
https://chatgpt.com/codex/tasks/task_e_68ceab991a90832a86893aeb1ab04bbb