### PR TITLE
feat: set page titles for routes

### DIFF
--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -1,12 +1,26 @@
 <script setup>
-import { onMounted, onUnmounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import AuthStore from '../scripts/authStore.js'
 import NotificationCenter from './NotificationCenter.vue'
 
 // Import Admin.Vue if username is 'admin'
 
 const router = useRouter()
+const route = useRoute()
+
+const appTitle = 'Teams Management'
+
+const currentTitle = computed(() => {
+  const matchedWithTitle = [...route.matched].reverse().find((record) => record.meta?.title)
+  const pageTitle = matchedWithTitle?.meta?.title
+
+  if (pageTitle && pageTitle !== appTitle) {
+    return pageTitle
+  }
+
+  return appTitle
+})
 
 const { getUserByAccessToken } = AuthStore
 // Controls the visibility of the navigation drawer.
@@ -144,7 +158,6 @@ const updateNavigationItems = () => {
 }
 
 // Watch for user changes to update navigation
-import { watch } from 'vue'
 watch(() => user.value.username, updateNavigationItems, { immediate: true })
 </script>
 
@@ -155,7 +168,7 @@ watch(() => user.value.username, updateNavigationItems, { immediate: true })
       <!-- The `d-lg-none` class hides drawer icon for large screens and up -->
       <v-app-bar-nav-icon @click="drawer = !drawer"></v-app-bar-nav-icon>
 
-      <v-toolbar-title>Teams Management</v-toolbar-title>
+      <v-toolbar-title>{{ currentTitle }}</v-toolbar-title>
 
       <v-spacer></v-spacer>
 

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -19,22 +19,67 @@ const { getUserByAccessToken } = AuthStore
 const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: '/', component: LandingView, meta: { requiresAuth: false, redirectIfAuthenticated: true } },
-    { path: '/landing', component: LandingView, meta: { requiresAuth: false, redirectIfAuthenticated: true } },
-    { path: '/login', component: Login, meta: { requiresAuth: false, redirectIfAuthenticated: true } },
-    { path: '/register', component: Register, meta: { requiresAuth: false, redirectIfAuthenticated: true } },
-    { path: '/forgot-password', component: ForgotPassword, meta: { requiresAuth: false } },
-    { path: '/reset-password', component: ResetPassword, meta: { requiresAuth: false } },
-    { path: '/verify-email', component: VerifyEmailView, meta: { requiresAuth: false } },
-    { path: '/teams', component: TeamsView, meta: { requiresAuth: true } },
-    { path: '/teams/:teamId', component: TeamDetails, meta: { requiresAuth: true } },
-    { path: '/about', component: AboutView, meta: { requiresAuth: true } },
-    { path: '/home', component: Dashboard, meta: { requiresAuth: true } },
-    { path: '/account/personal', component: AccountPersonalView, meta: { requiresAuth: true } },
-    { path: '/account/security', component: AccountSecurityView, meta: { requiresAuth: true } },
+    {
+      path: '/',
+      component: LandingView,
+      meta: { requiresAuth: false, redirectIfAuthenticated: true, title: 'Teams Management' },
+    },
+    {
+      path: '/landing',
+      component: LandingView,
+      meta: { requiresAuth: false, redirectIfAuthenticated: true, title: 'Teams Management' },
+    },
+    {
+      path: '/login',
+      component: Login,
+      meta: { requiresAuth: false, redirectIfAuthenticated: true, title: 'Sign In' },
+    },
+    {
+      path: '/register',
+      component: Register,
+      meta: { requiresAuth: false, redirectIfAuthenticated: true, title: 'Create Account' },
+    },
+    {
+      path: '/forgot-password',
+      component: ForgotPassword,
+      meta: { requiresAuth: false, title: 'Forgot Password' },
+    },
+    { path: '/reset-password', component: ResetPassword, meta: { requiresAuth: false, title: 'Reset Password' } },
+    { path: '/verify-email', component: VerifyEmailView, meta: { requiresAuth: false, title: 'Verify Email' } },
+    { path: '/teams', component: TeamsView, meta: { requiresAuth: true, title: 'Teams' } },
+    { path: '/teams/:teamId', component: TeamDetails, meta: { requiresAuth: true, title: 'Team Details' } },
+    { path: '/about', component: AboutView, meta: { requiresAuth: true, title: 'About' } },
+    { path: '/home', component: Dashboard, meta: { requiresAuth: true, title: 'Dashboard' } },
+    {
+      path: '/account/personal',
+      component: AccountPersonalView,
+      meta: { requiresAuth: true, title: 'Personal Information' },
+    },
+    {
+      path: '/account/security',
+      component: AccountSecurityView,
+      meta: { requiresAuth: true, title: 'Security Settings' },
+    },
     { path: '/account', redirect: '/account/personal' },
-    { path: '/admin', component: AdminView, meta: { requiresAuth: true, requiresAdmin: true } },
+    {
+      path: '/admin',
+      component: AdminView,
+      meta: { requiresAuth: true, requiresAdmin: true, title: 'Admin Panel' },
+    },
   ],
+})
+
+const defaultTitle = 'Teams Management'
+
+router.afterEach((to) => {
+  const nearestWithTitle = [...to.matched].reverse().find((routeRecord) => routeRecord.meta?.title)
+  const pageTitle = nearestWithTitle?.meta?.title
+
+  if (pageTitle && pageTitle !== defaultTitle) {
+    document.title = `${pageTitle} | ${defaultTitle}`
+  } else {
+    document.title = defaultTitle
+  }
 })
 
 router.beforeEach(async (to, from, next) => {


### PR DESCRIPTION
## Summary
- add route-level meta titles and update the document title after every navigation so browser history entries are descriptive
- surface the active view title in the sidebar toolbar for authenticated pages

## Testing
- bun run build

------
https://chatgpt.com/codex/tasks/task_e_68cfb2fde8d8832a88b4a22f138bc3b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic page titles: browser tab and app bar now reflect the current page, using descriptive titles across routes (e.g., Landing, Sign In, Create Account, Admin Panel).
  - Consistent titles across public and protected pages for clearer navigation and bookmarking.
  - Default base title applied when a page-specific title is unavailable.
  - Improves tab clarity and history readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->