### PR TITLE
Use Pinia for frontend auth state management

### DIFF
--- a/client/bun.lock
+++ b/client/bun.lock
@@ -7,6 +7,7 @@
         "@mdi/font": "^7.4.47",
         "@mdi/js": "^7.4.47",
         "dotenv": "^17.2.1",
+        "pinia": "^2.1.7",
         "shepherd.js": "^14.5.1",
         "vue": "^3.5.20",
         "vue-router": "^4.5.0",
@@ -527,6 +528,8 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "pinia": ["pinia@2.3.1", "", { "dependencies": { "@vue/devtools-api": "^6.6.3", "vue-demi": "^0.14.10" }, "peerDependencies": { "typescript": ">=4.4.4", "vue": "^2.7.0 || ^3.5.11" }, "optionalPeers": ["typescript"] }, "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
@@ -618,6 +621,8 @@
     "vite-plugin-vue-inspector": ["vite-plugin-vue-inspector@5.3.2", "", { "dependencies": { "@babel/core": "^7.23.0", "@babel/plugin-proposal-decorators": "^7.23.0", "@babel/plugin-syntax-import-attributes": "^7.22.5", "@babel/plugin-syntax-import-meta": "^7.10.4", "@babel/plugin-transform-typescript": "^7.22.15", "@vue/babel-plugin-jsx": "^1.1.5", "@vue/compiler-dom": "^3.3.4", "kolorist": "^1.8.0", "magic-string": "^0.30.4" }, "peerDependencies": { "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0" } }, "sha512-YvEKooQcSiBTAs0DoYLfefNja9bLgkFM7NI2b07bE2SruuvX0MEa9cMaxjKVMkeCp5Nz9FRIdcN1rOdFVBeL6Q=="],
 
     "vue": ["vue@3.5.21", "", { "dependencies": { "@vue/compiler-dom": "3.5.21", "@vue/compiler-sfc": "3.5.21", "@vue/runtime-dom": "3.5.21", "@vue/server-renderer": "3.5.21", "@vue/shared": "3.5.21" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA=="],
+
+    "vue-demi": ["vue-demi@0.14.10", "", { "peerDependencies": { "@vue/composition-api": "^1.0.0-rc.1", "vue": "^3.0.0-0 || ^2.6.0" }, "optionalPeers": ["@vue/composition-api"], "bin": { "vue-demi-fix": "bin/vue-demi-fix.js", "vue-demi-switch": "bin/vue-demi-switch.js" } }, "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg=="],
 
     "vue-eslint-parser": ["vue-eslint-parser@10.2.0", "", { "dependencies": { "debug": "^4.4.0", "eslint-scope": "^8.2.0", "eslint-visitor-keys": "^4.2.0", "espree": "^10.3.0", "esquery": "^1.6.0", "semver": "^7.6.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0" } }, "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@mdi/js": "^7.4.47",
     "dotenv": "^17.2.1",
     "shepherd.js": "^14.5.1",
+    "pinia": "^2.1.7",
     "vue": "^3.5.20",
     "vue-router": "^4.5.0",
     "vue3-google-login": "^2.0.33",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -7,7 +7,6 @@ import { useAuthStore } from './stores/auth.js'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
-authStore.initCrossTabSync()
 
 // Notification system
 const showSignOutDialog = ref(false)

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -2,9 +2,12 @@
 import SideBar from './components/Sidebar.vue'
 import { computed, onMounted, onUnmounted, watch, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from './stores/auth.js'
 
 const route = useRoute()
 const router = useRouter()
+const authStore = useAuthStore()
+authStore.initCrossTabSync()
 
 // Notification system
 const showSignOutDialog = ref(false)
@@ -14,9 +17,7 @@ const showSignOutPopup = (message = 'You have been signed out.') => {
   signOutMessage.value = message
   showSignOutDialog.value = true
 
-  // Clean up any stored session data
-  sessionStorage.removeItem('isLoggedIn')
-  localStorage.removeItem('currentUser')
+  authStore.clearAuth()
 
   // Stop auto refresh
   stopTokenRefresh()
@@ -48,7 +49,11 @@ const refreshAccessToken = async () => {
     })
 
     if (response.ok) {
-      sessionStorage.setItem('isLoggedIn', true)
+      authStore.setLoggedIn(true)
+
+      if (!authStore.user) {
+        await authStore.fetchUser()
+      }
       console.log('Access token auto-refreshed successfully')
       return true
     } else if (response.status === 401) {
@@ -66,6 +71,7 @@ const refreshAccessToken = async () => {
         console.error('Error parsing response:', parseError)
       }
 
+      authStore.clearAuth()
       console.warn('Auto token refresh failed:', response.status, response.statusText)
       return false
     } else {
@@ -74,6 +80,7 @@ const refreshAccessToken = async () => {
     }
   } catch (error) {
     console.error('Error during auto token refresh:', error)
+    authStore.clearAuth()
     return false
   }
 }

--- a/client/src/auth/Login.vue
+++ b/client/src/auth/Login.vue
@@ -6,7 +6,6 @@ import { useAuthStore } from '../stores/auth.js'
 
 const router = useRouter()
 const authStore = useAuthStore()
-authStore.initCrossTabSync()
 
 onMounted(async () => {
   try {

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -9,7 +9,6 @@ import NotificationCenter from './NotificationCenter.vue'
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
-authStore.initCrossTabSync()
 
 const appTitle = 'Teams Management'
 

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router/router'
 
@@ -10,11 +11,13 @@ import vue3GoogleLogin from 'vue3-google-login'
 const CLIENT_ID = import.meta.env.VITE_CLIENT_ID
 
 const app = createApp(App)
+const pinia = createPinia()
 
 app.use(vue3GoogleLogin, {
   clientId: CLIENT_ID,
 })
 
+app.use(pinia)
 app.use(router)
 app.use(vuetify)
 app.mount('#app')

--- a/client/src/router/router.js
+++ b/client/src/router/router.js
@@ -113,7 +113,6 @@ router.beforeEach(async (to, from, next) => {
   const requiresAdmin = to.matched.some((record) => record.meta.requiresAdmin)
   const redirectIfAuthenticated = to.matched.some((record) => record.meta.redirectIfAuthenticated)
   const authStore = useAuthStore()
-  authStore.initCrossTabSync()
 
   if (!requiresAuth && !redirectIfAuthenticated) {
     next()

--- a/client/src/router/router.js
+++ b/client/src/router/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import AuthStore from '../scripts/authStore.js'
+import { useAuthStore } from '../stores/auth.js'
 
 // Frequently used components - eagerly loaded for better performance
 import LandingView from '../views/LandingView.vue'
@@ -111,6 +112,8 @@ router.beforeEach(async (to, from, next) => {
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth)
   const requiresAdmin = to.matched.some((record) => record.meta.requiresAdmin)
   const redirectIfAuthenticated = to.matched.some((record) => record.meta.redirectIfAuthenticated)
+  const authStore = useAuthStore()
+  authStore.initCrossTabSync()
 
   if (!requiresAuth && !redirectIfAuthenticated) {
     next()
@@ -123,6 +126,8 @@ router.beforeEach(async (to, from, next) => {
     console.log('User fetched from authStore:', user)
 
     if (user) {
+      authStore.setUserFromApi(user)
+
       console.log('User authenticated successfully:', user.username)
 
       if (redirectIfAuthenticated) {
@@ -147,6 +152,7 @@ router.beforeEach(async (to, from, next) => {
     }
 
     if (requiresAuth) {
+      authStore.clearAuth()
       console.error('Authentication failed, redirecting to login')
       next('/login')
     } else {

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -1,0 +1,124 @@
+import { defineStore } from 'pinia'
+import AuthStore from '../scripts/authStore.js'
+
+const isClient = typeof window !== 'undefined'
+const hasBroadcastChannel = isClient && 'BroadcastChannel' in window
+
+const tabId =
+  isClient && typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `tab-${Math.random().toString(36).slice(2)}`
+
+const broadcastChannel = hasBroadcastChannel ? new BroadcastChannel('auth-store') : null
+let channelInitialized = false
+
+const normalizeUser = (userData) => {
+  if (!userData) return null
+
+  return {
+    userId: userData.userId ? userData.userId.toString() : '',
+    username: userData.username || '',
+    email: userData.email || '',
+    pendingEmail: userData.pendingEmail || null,
+    emailVerified: userData.emailVerified !== false,
+    lastUsernameChangeAt: userData.lastUsernameChangeAt || null,
+    lastEmailChangeAt: userData.lastEmailChangeAt || null,
+    emailVerificationExpires: userData.emailVerificationExpires || null,
+  }
+}
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    isLoggedIn: false,
+    user: null,
+    lastUpdateSource: tabId,
+  }),
+  getters: {
+    hasUser: (state) => !!state.user,
+    isExternalUpdate: (state) => state.lastUpdateSource !== tabId,
+  },
+  actions: {
+    setAuthentication({ isLoggedIn, user }, source = tabId, shouldBroadcast = true) {
+      this.isLoggedIn = !!isLoggedIn
+      this.user = user ? { ...user } : null
+      this.lastUpdateSource = source
+
+      if (!this.isLoggedIn) {
+        this.user = null
+      }
+
+      if (shouldBroadcast) {
+        this.broadcastState(source)
+      }
+    },
+    setLoggedIn(value, source = tabId, shouldBroadcast = true) {
+      this.setAuthentication({ isLoggedIn: value, user: value ? this.user : null }, source, shouldBroadcast)
+    },
+    setUser(user, source = tabId, shouldBroadcast = true) {
+      const normalized = user ? { ...user } : null
+      this.setAuthentication({ isLoggedIn: !!normalized, user: normalized }, source, shouldBroadcast)
+      return this.user
+    },
+    setUserFromApi(userData, source = tabId, shouldBroadcast = true) {
+      const normalized = normalizeUser(userData)
+      this.setAuthentication({ isLoggedIn: !!normalized, user: normalized }, source, shouldBroadcast)
+      return normalized
+    },
+    clearAuth(source = tabId, shouldBroadcast = true) {
+      this.setAuthentication({ isLoggedIn: false, user: null }, source, shouldBroadcast)
+    },
+    broadcastState(source = tabId) {
+      if (!broadcastChannel) return
+
+      broadcastChannel.postMessage({
+        source,
+        payload: {
+          isLoggedIn: this.isLoggedIn,
+          user: this.user,
+        },
+      })
+    },
+    initCrossTabSync() {
+      if (!broadcastChannel || channelInitialized) return
+
+      channelInitialized = true
+
+      broadcastChannel.addEventListener('message', (event) => {
+        const { source, payload } = event.data || {}
+        if (!payload || source === tabId) {
+          return
+        }
+
+        this.setAuthentication(
+          {
+            isLoggedIn: payload.isLoggedIn,
+            user: payload.user ? { ...payload.user } : null,
+          },
+          source,
+          false,
+        )
+      })
+    },
+    async fetchUser(source = tabId) {
+      const userData = await AuthStore.getUserByAccessToken()
+      if (userData) {
+        return this.setUserFromApi(userData, source)
+      }
+
+      return null
+    },
+    async ensureUser(source = tabId) {
+      if (this.user) {
+        return this.user
+      }
+
+      return await this.fetchUser(source)
+    },
+    async logout() {
+      await AuthStore.logout()
+      this.clearAuth()
+    },
+  },
+})
+
+export { tabId as authStoreTabId }

--- a/client/src/views/AccountPersonalView.vue
+++ b/client/src/views/AccountPersonalView.vue
@@ -393,7 +393,6 @@ export default {
   name: 'AccountPersonalView',
   setup() {
     const authStore = useAuthStore()
-    authStore.initCrossTabSync()
     return { authStore }
   },
   data() {

--- a/client/src/views/LandingView.vue
+++ b/client/src/views/LandingView.vue
@@ -1,13 +1,27 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth.js'
 
 const router = useRouter()
+const authStore = useAuthStore()
+authStore.initCrossTabSync()
 const isVisible = ref(false)
 
-onMounted(() => {
-  if (sessionStorage.getItem('isLoggedIn')) {
-    router.push('/home')
+onMounted(async () => {
+  try {
+    if (authStore.isLoggedIn && authStore.user) {
+      router.push('/home')
+      return
+    }
+
+    const existingUser = await authStore.ensureUser()
+    if (existingUser) {
+      router.push('/home')
+      return
+    }
+  } catch (error) {
+    console.error('Error checking authentication status:', error)
   }
   // Trigger animations after component is mounted
   setTimeout(() => {

--- a/client/src/views/LandingView.vue
+++ b/client/src/views/LandingView.vue
@@ -5,7 +5,6 @@ import { useAuthStore } from '../stores/auth.js'
 
 const router = useRouter()
 const authStore = useAuthStore()
-authStore.initCrossTabSync()
 const isVisible = ref(false)
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- add a Pinia-based auth store with BroadcastChannel syncing to centralize login and user data
- update the app shell, router, and major auth-related views/components to rely on the shared store instead of session/local storage
- wire Pinia into the Vue app bootstrap and preserve the guided tour's localStorage usage while removing other direct storage calls

## Testing
- bun run build

------
https://chatgpt.com/codex/tasks/task_e_68da6ad07898832a9a3a1d6045b3a8d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced centralized authentication via a store with cross‑tab synchronization.
  - Enabled app-wide state management using Pinia.
  - Added automatic session refresh and seamless user data loading.
- Refactor
  - Migrated authentication flows across app shell, login, router, landing, sidebar, and account views to the new store.
  - Replaced direct local/session storage usage with reactive state and computed user data.
  - Streamlined logout and navigation behaviors to rely on store-driven state.
- Chores
  - Added Pinia as a client dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->