### PR TITLE
Fix Redis cache-aside implementation and CSRF protection

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/plugin-deep-link": "~2",
     "@tauri-apps/plugin-process": "~2",
     "@tauri-apps/plugin-updater": "~2",
+    "axios": "^1.19.0",
     "dotenv": "^17.2.3",
     "pinia": "3.0.3",
     "vue": "^3.5.22",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import SideBar from './components/Sidebar.vue'
+import { fetchWithTokenRefresh } from './scripts/apiClient.js'
 import CacheDebugger from './components/CacheDebugger.vue'
 import GlobalNotifications from './components/GlobalNotifications.vue'
 import { computed, onMounted, onUnmounted, watch, ref } from 'vue'
@@ -79,7 +80,7 @@ const refreshAccessToken = async () => {
     try {
       const PORT = import.meta.env.VITE_API_PORT
       console.log('Auto-refreshing access token... (attempt', attempt + 1, ')')
-      const response = await fetch(`${PORT}/api/sessions/refresh`, {
+      const response = await fetchWithTokenRefresh(`${PORT}/api/sessions/refresh`, {
         method: 'POST',
         credentials: 'include',
       })

--- a/client/src/components/AnnouncementView.vue
+++ b/client/src/components/AnnouncementView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const success = ref(false)
 const error = ref(false)
@@ -84,7 +85,7 @@ const submitComment = async () => {
       replyTo: newComment.value.replyTo || '',
     }
 
-    const response = await fetch(`${PORT}/api/announcements/${props.announcement._id}/comments`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/announcements/${props.announcement._id}/comments`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/components/DeleteAnnouncements.vue
+++ b/client/src/components/DeleteAnnouncements.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const success = ref(false)
 const error = ref(false)
@@ -11,7 +12,7 @@ const deleteAnnouncement = async () => {
   loading.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/announcements/${props.announcementId}`,
       {
         method: 'DELETE',

--- a/client/src/components/DeleteMembers.vue
+++ b/client/src/components/DeleteMembers.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 
 const DEFAULT_ROLE_COLORS = {
@@ -91,7 +92,7 @@ const removeMembers = async () => {
     const membersToRemove = selectedMembers.value.map((member) => ({
       userId: member.userId,
     }))
-    const response = await fetch(`${PORT}/api/teams/${props.teamId}/users/`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${props.teamId}/users/`, {
       method: 'DELETE',
       credentials: 'include', // Include cookies for authentication
       headers: {

--- a/client/src/components/DeleteTeams.vue
+++ b/client/src/components/DeleteTeams.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -76,7 +77,7 @@ const deleteTeams = async (teamId) => {
     // Logic to delete teams goes here
     // For example, you might call an API endpoint to delete the selected teams
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/${teamId}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${teamId}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/components/NewAnnouncements.vue
+++ b/client/src/components/NewAnnouncements.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -49,7 +50,7 @@ const createAnnouncement = async () => {
   }
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/${props.teamId}/announcements`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${props.teamId}/announcements`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/components/NewMembers.vue
+++ b/client/src/components/NewMembers.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const user = ref({
   userId: '',
@@ -91,7 +92,7 @@ const emit = defineEmits(['update:dialog', 'members-added'])
 const fetchUsers = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/users/all`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/users/all`, {
       method: 'GET',
       credentials: 'include',
       headers: {
@@ -119,7 +120,7 @@ const fetchRoles = async () => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/${props.teamId}/roles`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${props.teamId}/roles`, {
       method: 'GET',
       credentials: 'include',
       headers: {
@@ -168,7 +169,7 @@ const fetchRoles = async () => {
 const sendMembersToServer = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/${props.teamId}/users`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${props.teamId}/users`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/client/src/components/NewTasks.vue
+++ b/client/src/components/NewTasks.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { permissionService } from '../services/permissionService.js'
 
 const user = ref({
@@ -245,7 +246,7 @@ const createTask = async () => {
     if (taskForm.value.description === undefined) {
       taskForm.value.description = ''
     }
-    const response = await fetch(`${PORT}/api/tasks/create`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/tasks/create`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/client/src/components/NewTeams.vue
+++ b/client/src/components/NewTeams.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 import { useGlobalNotifications } from '../composables/useGlobalNotifications.js'
 import '../styles/buttonStyling.css'
@@ -71,7 +72,7 @@ const props = defineProps({
 const fetchCategories = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/categories`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/categories`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -140,7 +141,7 @@ const createTeam = async () => {
   console.log('Creating project with data:', newTeam.value)
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/components/NotificationCenter.vue
+++ b/client/src/components/NotificationCenter.vue
@@ -163,6 +163,7 @@
 
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -237,7 +238,7 @@ const loadNotifications = async (page = 1) => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/notifications/${props.userId}?page=${page}&limit=20`,
       {
         method: 'GET',
@@ -279,7 +280,7 @@ const markAllAsRead = async () => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/notifications/${props.userId}/mark-read`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/notifications/${props.userId}/mark-read`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -378,7 +379,7 @@ const handleNotificationClick = async (notification) => {
 const markNotificationAsRead = async (notificationId) => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    await fetch(`${PORT}/api/notifications/${props.userId}/mark-read`, {
+    await fetchWithTokenRefresh(`${PORT}/api/notifications/${props.userId}/mark-read`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -393,7 +394,7 @@ const markNotificationAsRead = async (notificationId) => {
 const deleteNotification = async (notificationId) => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/notifications/${props.userId}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/notifications/${props.userId}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -427,7 +428,7 @@ const openSettings = () => {
 const loadPreferences = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/notifications/${props.userId}/preferences`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/notifications/${props.userId}/preferences`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -455,7 +456,7 @@ const saveSettings = async () => {
       admin: { enabled: true }, // Admin notifications should always be enabled
     }
 
-    const response = await fetch(`${PORT}/api/notifications/${props.userId}/preferences`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/notifications/${props.userId}/preferences`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/components/RoleManagement.vue
+++ b/client/src/components/RoleManagement.vue
@@ -473,6 +473,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { permissionService } from '../services/permissionService.js'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const props = defineProps({
   dialog: {
@@ -585,7 +586,7 @@ const executeRoleChange = async (member, newRoleType) => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/members/${member.userId}/assign-role`,
       {
         method: 'PUT',
@@ -666,7 +667,7 @@ const openPermissionsDialog = async (member) => {
   // Fetch member's current permissions
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/members/${member.userId}/permissions`,
       {
         method: 'GET',

--- a/client/src/components/RoleManagementTabs.vue
+++ b/client/src/components/RoleManagementTabs.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { permissionService, AVAILABLE_PERMISSIONS } from '../services/permissionService.js'
 
 const props = defineProps({
@@ -156,7 +157,7 @@ const fetchCustomRoles = async () => {
   try {
     loading.value = true
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/${props.teamId}/roles`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${props.teamId}/roles`, {
       method: 'GET',
       credentials: 'include',
       headers: {
@@ -182,7 +183,7 @@ const createCustomRole = async () => {
   try {
     loading.value = true
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/${props.teamId}/roles`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${props.teamId}/roles`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -219,7 +220,7 @@ const updateCustomRole = async () => {
   try {
     loading.value = true
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/roles/${selectedRole.value._id}`,
       {
         method: 'PUT',
@@ -258,7 +259,7 @@ const deleteCustomRole = async () => {
   try {
     loading.value = true
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/roles/${selectedRole.value._id}`,
       {
         method: 'DELETE',
@@ -299,7 +300,7 @@ const assignRole = async (member, roleType, roleId = null) => {
       roleId: roleId || null,
     }
 
-    const response = await fetch(endpoint, {
+    const response = await fetchWithTokenRefresh(endpoint, {
       method: 'PUT',
       credentials: 'include',
       headers: {

--- a/client/src/components/SprintManagement.vue
+++ b/client/src/components/SprintManagement.vue
@@ -99,6 +99,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const props = defineProps({
   teamId: {
@@ -137,7 +138,7 @@ const getSprintColor = (status) => {
 const fetchSprints = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/sprints/team/${props.teamId}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/sprints/team/${props.teamId}`, {
       method: 'GET',
       credentials: 'include',
     })
@@ -160,7 +161,7 @@ const createSprint = async () => {
   creating.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/sprints`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/sprints`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -192,7 +193,7 @@ const createSprint = async () => {
 const startSprint = async (sprintId) => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/sprints/${sprintId}/start`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/sprints/${sprintId}/start`, {
       method: 'POST',
       credentials: 'include',
     })
@@ -213,7 +214,7 @@ const startSprint = async (sprintId) => {
 const completeSprint = async (sprintId) => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/sprints/${sprintId}/complete`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/sprints/${sprintId}/complete`, {
       method: 'POST',
       credentials: 'include',
     })
@@ -236,7 +237,7 @@ const deleteSprint = async (sprintId) => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/sprints/${sprintId}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/sprints/${sprintId}`, {
       method: 'DELETE',
       credentials: 'include',
     })

--- a/client/src/components/TaskActivity.vue
+++ b/client/src/components/TaskActivity.vue
@@ -28,6 +28,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const props = defineProps({
   taskId: {
@@ -98,7 +99,7 @@ const getActivityText = (activity) => {
 const fetchActivity = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/tasks/${props.taskId}/activity`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/tasks/${props.taskId}/activity`, {
       method: 'GET',
       credentials: 'include',
     })

--- a/client/src/components/TaskComments.vue
+++ b/client/src/components/TaskComments.vue
@@ -84,6 +84,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const props = defineProps({
   taskId: {
@@ -112,7 +113,7 @@ const formatDate = (dateString) => {
 const fetchComments = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/comments/tasks/${props.taskId}/comments`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/comments/tasks/${props.taskId}/comments`, {
       method: 'GET',
       credentials: 'include',
     })
@@ -132,7 +133,7 @@ const addComment = async () => {
   loading.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/comments/tasks/${props.taskId}/comments`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/comments/tasks/${props.taskId}/comments`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -172,7 +173,7 @@ const saveEdit = async (commentId) => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/comments/comments/${commentId}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/comments/comments/${commentId}`, {
       method: 'PATCH',
       credentials: 'include',
       headers: {
@@ -199,7 +200,7 @@ const deleteComment = async (commentId) => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/comments/comments/${commentId}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/comments/comments/${commentId}`, {
       method: 'DELETE',
       credentials: 'include',
     })

--- a/client/src/components/TaskStatusSelector.vue
+++ b/client/src/components/TaskStatusSelector.vue
@@ -28,6 +28,7 @@
 
 <script setup>
 import { ref, watch } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const props = defineProps({
   status: {
@@ -83,7 +84,7 @@ const updateStatus = async (newStatus) => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/tasks/${props.taskId}/status`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/tasks/${props.taskId}/status`, {
       method: 'PATCH',
       credentials: 'include',
       headers: {

--- a/client/src/components/TaskSubmission.vue
+++ b/client/src/components/TaskSubmission.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -145,7 +146,7 @@ const uploadImageToServer = async (imageData, filename) => {
   const PORT = import.meta.env.VITE_API_PORT
 
   try {
-    const response = await fetch(`${PORT}/api/images/upload`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/images/upload`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -372,7 +373,7 @@ const submitTaskResponse = async () => {
     submissionData.submissionDate = new Date().toISOString()
 
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/tasks/submit`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/tasks/submit`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/client/src/components/TaskTimeTracking.vue
+++ b/client/src/components/TaskTimeTracking.vue
@@ -86,6 +86,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const props = defineProps({
   taskId: {
@@ -144,7 +145,7 @@ const updateEstimate = async () => {
   updatingEstimate.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/tasks/${props.taskId}/estimate`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/tasks/${props.taskId}/estimate`, {
       method: 'PATCH',
       credentials: 'include',
       headers: {
@@ -175,7 +176,7 @@ const logTime = async () => {
   loggingTime.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/tasks/${props.taskId}/log-time`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/tasks/${props.taskId}/log-time`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/client/src/components/UpdateAnnouncements.vue
+++ b/client/src/components/UpdateAnnouncements.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const success = ref(false)
 const error = ref(false)
@@ -70,7 +71,7 @@ const updateAnnouncement = async () => {
   loading.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/announcements/${props.announcement._id}`,
       {
         method: 'PUT',

--- a/client/src/components/UpdateTaskGroups.vue
+++ b/client/src/components/UpdateTaskGroups.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue'
 import EnhancedTaskView from './EnhancedTaskView.vue'
 import { permissionService } from '../services/permissionService.js'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const emit = defineEmits(['update:dialog', 'task-group-updated'])
 
@@ -113,7 +114,7 @@ const fetchTaskGroupDetails = async () => {
   loading.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/task-groups/${props.taskGroupId}`,
       {
         method: 'GET',
@@ -175,7 +176,7 @@ const updateTaskGroup = async () => {
 
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/task-groups/${props.taskGroupId}`,
       {
         method: 'PUT',
@@ -236,7 +237,7 @@ const deleteTaskGroup = async () => {
   saving.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/task-groups/${props.taskGroupId}`,
       {
         method: 'DELETE',

--- a/client/src/components/ViewTask.vue
+++ b/client/src/components/ViewTask.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 const emit = defineEmits(['update:dialog'])
 
@@ -56,7 +57,7 @@ const fetchTaskDetails = async () => {
     const PORT = import.meta.env.VITE_API_PORT
 
     // First, get the task details from the task group
-    const taskGroupResponse = await fetch(
+    const taskGroupResponse = await fetchWithTokenRefresh(
       `${PORT}/api/teams/${props.teamId}/task-groups/${props.task.taskGroupId}`,
       {
         method: 'GET',
@@ -77,7 +78,7 @@ const fetchTaskDetails = async () => {
     }
 
     // Then, try to get the submission details
-    const submissionResponse = await fetch(
+    const submissionResponse = await fetchWithTokenRefresh(
       `${PORT}/api/tasks/submission/${props.teamId}/${props.task._id}`,
       {
         method: 'GET',

--- a/client/src/scripts/apiClient.js
+++ b/client/src/scripts/apiClient.js
@@ -1,40 +1,77 @@
 /**
- * API Client with automatic token refresh on 401 errors and CSRF protection
+ * Global API client with token refresh and CSRF protection.
  *
- * This module provides a centralized fetch wrapper that automatically handles
- * expired access tokens by refreshing them and retrying the original request,
- * and includes CSRF tokens for state-changing requests.
- *
- * Usage:
- *   import { fetchWithTokenRefresh, fetchJSON } from '../scripts/apiClient.js'
- *
- *   // Using fetchWithTokenRefresh (returns Response object)
- *   const response = await fetchWithTokenRefresh('/api/teams', { method: 'GET' })
- *
- *   // Using fetchJSON (returns parsed JSON)
- *   const { ok, status, data } = await fetchJSON('/api/teams', { method: 'GET' })
+ * Exposes a fetch-compatible wrapper so existing call sites can keep using
+ * response.ok/response.json() while requests run through a single Axios client.
  */
 
+import axios from 'axios'
 import { useComponentCache } from '../composables/useComponentCache.js'
 import { getCsrfToken, addCsrfHeader, fetchCsrfToken } from '../services/csrfService.js'
 
 const API_PORT = import.meta.env.VITE_API_PORT || 'http://localhost:3000'
 
+const apiAxios = axios.create({
+  baseURL: API_PORT,
+  withCredentials: true,
+  validateStatus: () => true,
+})
+
+const normalizeHeaders = (headers) => {
+  if (!headers) return {}
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries())
+  }
+  return headers
+}
+
+const toFetchResponse = (axiosResponse) => {
+  const headers = new Headers()
+  Object.entries(axiosResponse.headers || {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      headers.set(key, Array.isArray(value) ? value.join(', ') : String(value))
+    }
+  })
+
+  let body = null
+  if (axiosResponse.data !== undefined && axiosResponse.data !== null) {
+    if (typeof axiosResponse.data === 'string') {
+      body = axiosResponse.data
+    } else if (
+      axiosResponse.data instanceof ArrayBuffer ||
+      ArrayBuffer.isView(axiosResponse.data)
+    ) {
+      body = axiosResponse.data
+    } else {
+      body = JSON.stringify(axiosResponse.data)
+      if (!headers.get('content-type')) {
+        headers.set('content-type', 'application/json')
+      }
+    }
+  }
+
+  return new Response(body, {
+    status: axiosResponse.status,
+    statusText: axiosResponse.statusText || '',
+    headers,
+  })
+}
+
 const refreshAccessToken = async () => {
   try {
     console.log('[API Client] Attempting to refresh access token...')
-    const response = await fetch(`${API_PORT}/api/auth/tokens/access`, {
+    const response = await apiAxios.request({
+      url: '/api/auth/tokens/access',
       method: 'GET',
-      credentials: 'include', // Important for cookies - sends refresh token
     })
 
-    if (response.ok) {
+    if (response.status >= 200 && response.status < 300) {
       console.log('[API Client] Access token refreshed successfully')
       return { success: true }
     } else if (response.status === 401) {
       // Check if it's a token revocation/expiration error
       try {
-        const errorData = await response.json()
+        const errorData = response.data || {}
         if (errorData.error === 'TOKEN_REVOKED' || errorData.error === 'TOKEN_INVALID') {
           console.warn('⚠️ [API Client] Token was revoked or invalid:', errorData.error)
 
@@ -53,7 +90,7 @@ const refreshAccessToken = async () => {
       }
     }
 
-    console.log('[API Client] Failed to refresh access token:', response.statusText)
+    console.log('[API Client] Failed to refresh access token:', response.statusText || response.status)
     return { success: false, tokenRevoked: false }
   } catch (error) {
     console.log('[API Client] Error refreshing access token:', error)
@@ -64,28 +101,49 @@ const refreshAccessToken = async () => {
 export const fetchWithTokenRefresh = async (url, options = {}, retryCount = 0) => {
   const fetchOptions = {
     ...options,
-    credentials: options.credentials || 'include',
   }
 
   // Add CSRF token for non-GET requests
   const method = fetchOptions.method?.toUpperCase() || 'GET'
   if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
     await getCsrfToken()
-    fetchOptions.headers = addCsrfHeader(fetchOptions.headers || {})
+    fetchOptions.headers = addCsrfHeader(normalizeHeaders(fetchOptions.headers))
   }
 
   try {
-    const response = await fetch(url, fetchOptions)
+    const response = await apiAxios.request({
+      url,
+      method: fetchOptions.method || 'GET',
+      headers: normalizeHeaders(fetchOptions.headers),
+      data: fetchOptions.body,
+      signal: fetchOptions.signal,
+      withCredentials: fetchOptions.credentials !== 'omit',
+      responseType: 'text',
+      transformResponse: [
+        (value, headers) => {
+          const contentType = headers?.['content-type'] || ''
+          if (typeof value === 'string' && contentType.includes('application/json')) {
+            try {
+              return JSON.parse(value)
+            } catch {
+              return value
+            }
+          }
+          return value
+        },
+      ],
+    })
+    const fetchLikeResponse = toFetchResponse(response)
 
     // If request succeeded, return as-is
-    if (response.ok) {
-      return response
+    if (fetchLikeResponse.ok) {
+      return fetchLikeResponse
     }
 
     // Handle 403 CSRF errors — refresh token and retry once
-    if (response.status === 403 && retryCount === 0) {
+    if (fetchLikeResponse.status === 403 && retryCount === 0) {
       try {
-        const cloned = response.clone()
+        const cloned = fetchLikeResponse.clone()
         const body = await cloned.json()
         if (body?.error?.includes('CSRF')) {
           await fetchCsrfToken()
@@ -94,12 +152,12 @@ export const fetchWithTokenRefresh = async (url, options = {}, retryCount = 0) =
       } catch {}
     }
 
-    if (response.status !== 401) {
-      return response
+    if (fetchLikeResponse.status !== 401) {
+      return fetchLikeResponse
     }
 
     // Handle 401 - Try to refresh token (only once to prevent infinite loops)
-    if (response.status === 401 && retryCount === 0) {
+    if (fetchLikeResponse.status === 401 && retryCount === 0) {
       console.log(`[API Client] Received 401 for ${url}, attempting token refresh...`)
 
       const refreshResult = await refreshAccessToken()
@@ -116,15 +174,15 @@ export const fetchWithTokenRefresh = async (url, options = {}, retryCount = 0) =
           }),
         )
 
-        return response
+        return fetchLikeResponse
       } else {
         console.log('[API Client] Token refresh failed, returning 401 response')
-        return response
+        return fetchLikeResponse
       }
     }
 
     console.warn(`⚠️ [API Client] Already retried once for ${url}, returning 401`)
-    return response
+    return fetchLikeResponse
   } catch (error) {
     console.log(`[API Client] Fetch error for ${url}:`, error)
     throw error

--- a/client/src/scripts/apiClient.js
+++ b/client/src/scripts/apiClient.js
@@ -16,7 +16,7 @@
  */
 
 import { useComponentCache } from '../composables/useComponentCache.js'
-import { getCsrfToken, addCsrfHeader } from '../services/csrfService.js'
+import { getCsrfToken, addCsrfHeader, fetchCsrfToken } from '../services/csrfService.js'
 
 const API_PORT = import.meta.env.VITE_API_PORT || 'http://localhost:3000'
 
@@ -77,8 +77,24 @@ export const fetchWithTokenRefresh = async (url, options = {}, retryCount = 0) =
   try {
     const response = await fetch(url, fetchOptions)
 
-    // If request succeeded or it's not a 401, return as-is
-    if (response.ok || response.status !== 401) {
+    // If request succeeded, return as-is
+    if (response.ok) {
+      return response
+    }
+
+    // Handle 403 CSRF errors — refresh token and retry once
+    if (response.status === 403 && retryCount === 0) {
+      try {
+        const cloned = response.clone()
+        const body = await cloned.json()
+        if (body?.error?.includes('CSRF')) {
+          await fetchCsrfToken()
+          return await fetchWithTokenRefresh(url, options, 1)
+        }
+      } catch {}
+    }
+
+    if (response.status !== 401) {
       return response
     }
 

--- a/client/src/services/sessionService.js
+++ b/client/src/services/sessionService.js
@@ -1,3 +1,4 @@
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 /**
  * Session Service - RefreshToken-based session management
  * Replaces the old session management with refresh token activity tracking
@@ -16,7 +17,7 @@ class SessionService {
   async getActiveSessions() {
     const PORT = import.meta.env.VITE_API_PORT
     try {
-      const response = await fetch(`${PORT}/api/sessions/active`, {
+      const response = await fetchWithTokenRefresh(`${PORT}/api/sessions/active`, {
         method: 'GET',
         credentials: 'include',
       })
@@ -43,7 +44,7 @@ class SessionService {
   async checkSecurity() {
     const PORT = import.meta.env.VITE_API_PORT
     try {
-      const response = await fetch(`${PORT}/api/sessions/security`, {
+      const response = await fetchWithTokenRefresh(`${PORT}/api/sessions/security`, {
         method: 'GET',
         credentials: 'include',
       })
@@ -79,7 +80,7 @@ class SessionService {
   async revokeSession(sessionId) {
     const PORT = import.meta.env.VITE_API_PORT
     try {
-      const response = await fetch(`${PORT}/api/sessions/${sessionId}`, {
+      const response = await fetchWithTokenRefresh(`${PORT}/api/sessions/${sessionId}`, {
         method: 'DELETE',
         credentials: 'include',
       })
@@ -103,7 +104,7 @@ class SessionService {
   async revokeAllOtherSessions() {
     const PORT = import.meta.env.VITE_API_PORT
     try {
-      const response = await fetch(`${PORT}/api/sessions/others/all`, {
+      const response = await fetchWithTokenRefresh(`${PORT}/api/sessions/others/all`, {
         method: 'DELETE',
         credentials: 'include',
       })

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useComponentCache } from '../composables/useComponentCache.js'
 
 const isClient = typeof window !== 'undefined'
@@ -60,7 +61,7 @@ export const useAuthStore = defineStore('auth', {
     async refreshAccessToken() {
       try {
         console.log('Attempting to refresh access token...')
-        const response = await fetch(`${PORT}/api/auth/tokens/access`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/auth/tokens/access`, {
           method: 'GET',
           credentials: 'include',
         })
@@ -96,7 +97,7 @@ export const useAuthStore = defineStore('auth', {
     },
     async getUserByAccessToken(retryCount = 0) {
       try {
-        const response = await fetch(`${PORT}/api/users`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/users`, {
           method: 'GET',
           credentials: 'include',
         })
@@ -149,7 +150,7 @@ export const useAuthStore = defineStore('auth', {
           return { success: true, message: 'Already logged out' }
         }
 
-        const response = await fetch(`${PORT}/api/sessions/me`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/sessions/me`, {
           method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',

--- a/client/src/views/AccountPersonalView.vue
+++ b/client/src/views/AccountPersonalView.vue
@@ -392,6 +392,7 @@
 
 <script>
 import { useAuthStore } from '../stores/auth.js'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 
 export default {
   name: 'AccountPersonalView',
@@ -633,7 +634,7 @@ export default {
           username: this.editForm.username.trim(),
           email: this.editForm.email.trim(),
         }
-        const response = await fetch(`${PORT}/api/users/profile`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/users/profile`, {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
@@ -707,7 +708,7 @@ export default {
       try {
         const PORT = import.meta.env.VITE_API_PORT
         const payload = { username: this.editUsernameForm.username.trim() }
-        const response = await fetch(`${PORT}/api/users/profile`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/users/profile`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -752,7 +753,7 @@ export default {
       try {
         const PORT = import.meta.env.VITE_API_PORT
         const payload = { email: this.editEmailForm.email.trim() }
-        const response = await fetch(`${PORT}/api/users/profile`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/users/profile`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -800,7 +801,7 @@ export default {
       this.isDeleting = true
       try {
         const PORT = import.meta.env.VITE_API_PORT
-        const response = await fetch(`${PORT}/api/users/account`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/users/account`, {
           method: 'DELETE',
           headers: {
             'Content-Type': 'application/json',
@@ -841,7 +842,7 @@ export default {
       this.isResettingPassword = true
       try {
         const PORT = import.meta.env.VITE_API_PORT
-        const response = await fetch(`${PORT}/api/auth/forgot-password`, {
+        const response = await fetchWithTokenRefresh(`${PORT}/api/auth/forgot-password`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/client/src/views/AdminView.vue
+++ b/client/src/views/AdminView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import UpdateAnnouncements from '../components/UpdateAnnouncements.vue'
@@ -94,7 +95,7 @@ const loadAllData = async () => {
 const loadTeams = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/admin/teams`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/admin/teams`, {
       method: 'GET',
       credentials: 'include',
     })
@@ -112,7 +113,7 @@ const loadTeams = async () => {
 const loadUsers = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/admin/users`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/admin/users`, {
       method: 'GET',
       credentials: 'include',
     })
@@ -133,7 +134,7 @@ const loadUsers = async () => {
 const loadAnnouncements = async () => {
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/admin/announcements`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/admin/announcements`, {
       method: 'GET',
       credentials: 'include',
       headers: {
@@ -172,7 +173,7 @@ const deleteTeam = async (team) => {
   deleting.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/admin/teams/${team._id}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/admin/teams/${team._id}`, {
       method: 'DELETE',
       credentials: 'include',
     })
@@ -203,7 +204,7 @@ const sendNotification = async () => {
   console.log('Sending notification to user:', selectedUser.value)
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/admin/notify`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/admin/notify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -241,7 +242,7 @@ const deleteUser = async (userToDelete) => {
   deleting.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(
+    const response = await fetchWithTokenRefresh(
       `${PORT}/api/admin/users/${userToDelete._id}`, // Never change this endpoint
       {
         method: 'DELETE',
@@ -278,7 +279,7 @@ const deleteAnnouncement = async (announcement) => {
   deleting.value = true
   try {
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/admin/announcements/${announcement._id}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/admin/announcements/${announcement._id}`, {
       method: 'DELETE',
       credentials: 'include',
     })

--- a/client/src/views/FeedbackView.vue
+++ b/client/src/views/FeedbackView.vue
@@ -129,6 +129,7 @@
 
 <script setup>
 import { ref, onActivated, onMounted } from 'vue'
+import { fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { useRouter } from 'vue-router'
 import { useComponentCache } from '../composables/useComponentCache.js'
 import { useAuthStore } from '../stores/auth.js'
@@ -236,7 +237,7 @@ const submitFeedback = async () => {
       issue: feedback.value.experience, // Map experience to issue field for backend compatibility
     }
 
-    const res = await fetch(`${PORT}/api/ratings`, {
+    const res = await fetchWithTokenRefresh(`${PORT}/api/ratings`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/client/src/views/TeamDetails.vue
+++ b/client/src/views/TeamDetails.vue
@@ -10,7 +10,7 @@ import {
 } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
-import { fetchJSON } from '../scripts/apiClient.js'
+import { fetchJSON, fetchWithTokenRefresh } from '../scripts/apiClient.js'
 import { permissionService } from '../services/permissionService.js'
 import { useComponentCache } from '../composables/useComponentCache.js'
 
@@ -893,7 +893,7 @@ const confirmDeleteTeam = async () => {
     isDeletingTeam.value = true
 
     const PORT = import.meta.env.VITE_API_PORT
-    const response = await fetch(`${PORT}/api/teams/${teamId.value}`, {
+    const response = await fetchWithTokenRefresh(`${PORT}/api/teams/${teamId.value}`, {
       method: 'DELETE',
       credentials: 'include',
       headers: {

--- a/server/app.js
+++ b/server/app.js
@@ -31,7 +31,7 @@ app.use(
 
 // Initialize database and Redis
 connectDB()
-initRedis()
+const redisReady = initRedis()
 
 app.use((req, _res, next) => {
   Object.defineProperty(req, 'query', {
@@ -74,9 +74,11 @@ const PORT = process.env.PORT || 3000
 // Start token cleanup scheduler
 // initTokenCleanup()
 
-// For local development
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`)
+// Ensure Redis is connected before accepting requests
+redisReady.then(() => {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`)
+  })
 })
 
 // Export for Vercel

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -3,27 +3,24 @@ import { RedisStore } from 'rate-limit-redis'
 import { getRedisClient, isRedisReady } from '../config/redis.js'
 
 /**
- * Creates a rate limiter with Redis store (when available)
- * @param {object} options - Rate limiter options
- * @param {string} prefix - Redis key prefix
+ * Creates a rate limiter with Redis store (when available).
+ * The Redis store lazily checks readiness per-command, so it works even when
+ * the limiter is created before Redis finishes connecting.
  */
 export const createRateLimiter = (options, prefix = 'rl:') => {
   const limiterOptions = {
     ...options,
     standardHeaders: options.standardHeaders || 'draft-8',
     legacyHeaders: options.legacyHeaders !== undefined ? options.legacyHeaders : false,
-  }
-
-  // Try to use Redis store if available
-  try {
-    if (isRedisReady()) {
-      limiterOptions.store = new RedisStore({
-        sendCommand: (...args) => getRedisClient().sendCommand(args),
-        prefix,
-      })
-    }
-  } catch (error) {
-    console.warn(`Rate limiter (${prefix}): Redis store unavailable, using memory store`)
+    store: new RedisStore({
+      sendCommand: (...args) => {
+        if (!isRedisReady()) {
+          throw new Error('Redis not ready')
+        }
+        return getRedisClient().sendCommand(args)
+      },
+      prefix,
+    }),
   }
 
   return rateLimit(limiterOptions)

--- a/server/routes/tasks_routes.js
+++ b/server/routes/tasks_routes.js
@@ -2,6 +2,7 @@ import express from 'express'
 import TasksController from '../controllers/tasksController.js'
 import { authenticateAccessToken } from '../middleware/authMiddleware.js'
 import { requirePermission } from '../middleware/roleMiddleware.js'
+import { invalidateCache } from '../middleware/cacheMiddleware.js'
 
 const {
   addTaskToUsers,
@@ -19,8 +20,8 @@ const {
 } = TasksController
 const router = express.Router()
 
-router.post('/create', authenticateAccessToken, requirePermission('MANAGE_TASKS'), addTaskToUsers)
-router.post('/submit', authenticateAccessToken, requirePermission('SUBMIT_TASKS'), submitATask)
+router.post('/create', authenticateAccessToken, requirePermission('MANAGE_TASKS'), invalidateCache('cache:team::teamId:*'), addTaskToUsers)
+router.post('/submit', authenticateAccessToken, requirePermission('SUBMIT_TASKS'), invalidateCache('cache:team::teamId:*'), submitATask)
 router.get(
   '/submission/:teamId/:taskId',
   authenticateAccessToken,

--- a/server/routes/teams_routes.js
+++ b/server/routes/teams_routes.js
@@ -49,21 +49,21 @@ const {
 // Categories are static - cache for 24 hours
 router.get('/categories', cacheResponse(86400), getCategories)
 
-// Create team - invalidate user's team cache
-router.post('/', invalidateCache('cache:user:*:/'), addTeamPro)
+// Create team - invalidate user's team list caches
+router.post('/', invalidateCache('cache:user:*'), addTeamPro)
 
 router.post(
   '/:teamId/users/',
   authenticateAccessToken,
   requirePermission('ADD_MEMBERS'),
-  invalidateCache('cache:*:teamUsers:*', 'cache:user:*:/'),
+  invalidateCache('cache:team::teamId:*', 'cache:user:*'),
   addUsersToTeam,
 )
 router.delete(
   '/:teamId/users/',
   authenticateAccessToken,
   requirePermission('REMOVE_MEMBERS'),
-  invalidateCache('cache:*:teamUsers:*', 'cache:user:*:/'),
+  invalidateCache('cache:team::teamId:*', 'cache:user:*'),
   deleteUsersFromTeam,
 )
 
@@ -95,12 +95,12 @@ router.get(
   getTeamDetails,
 )
 
-// Delete team - invalidate all related caches
+// Delete team - invalidate team and user list caches
 router.delete(
   '/:teamId',
   authenticateAccessToken,
   requireAdmin,
-  invalidateCache('cache:*'),
+  invalidateCache('cache:team::teamId:*', 'cache:user:*'),
   deleteATeam,
 )
 
@@ -118,7 +118,7 @@ router.get(
   '/:teamId/:userId/tasks',
   authenticateAccessToken,
   requirePermission('VIEW_TEAM'),
-  cacheResponse(120),
+  cacheResponse(120, teamCacheKey),
   getTasksOfAUserInATeam,
 )
 
@@ -141,14 +141,14 @@ router.put(
   '/:teamId/task-groups/:taskGroupId',
   authenticateAccessToken,
   requirePermission('MANAGE_TASKS'),
-  invalidateCache('cache:*:task-groups*'),
+  invalidateCache('cache:team::teamId:*'),
   updateTaskGroup,
 )
 router.delete(
   '/:teamId/task-groups/:taskGroupId',
   authenticateAccessToken,
   requirePermission('DELETE_TASKS'),
-  invalidateCache('cache:*:task-groups*'),
+  invalidateCache('cache:team::teamId:*'),
   deleteTaskGroup,
 )
 
@@ -164,21 +164,21 @@ router.post(
   '/:teamId/announcements',
   authenticateAccessToken,
   requirePermission('MANAGE_ANNOUNCEMENTS'),
-  invalidateCache('cache:*:announcements*'),
+  invalidateCache('cache:team::teamId:*'),
   addAnnouncement,
 )
 router.put(
   '/:teamId/announcements/:announcementId',
   authenticateAccessToken,
   requirePermission('MANAGE_ANNOUNCEMENTS'),
-  invalidateCache('cache:*:announcements*'),
+  invalidateCache('cache:team::teamId:*'),
   updateAnnouncement,
 )
 router.delete(
   '/:teamId/announcements/:announcementId',
   authenticateAccessToken,
   requirePermission('DELETE_ANNOUNCEMENTS'),
-  invalidateCache('cache:*:announcements*'),
+  invalidateCache('cache:team::teamId:*'),
   deleteAnnouncement,
 )
 
@@ -186,7 +186,7 @@ router.put(
   '/:teamId/members/:userId/role',
   authenticateAccessToken,
   requireAdmin,
-  invalidateCache('cache:*:users*', 'cache:*:permissions*'),
+  invalidateCache('cache:team::teamId:*'),
   changeUserRole,
 )
 router.get(
@@ -200,7 +200,7 @@ router.put(
   '/:teamId/members/:userId/permissions',
   authenticateAccessToken,
   requireAdmin,
-  invalidateCache('cache:*:permissions*'),
+  invalidateCache('cache:team::teamId:*'),
   updateUserPermissions,
 )
 
@@ -209,7 +209,7 @@ router.post(
   '/:teamId/roles',
   authenticateAccessToken,
   requireAdmin,
-  invalidateCache('cache:*:roles*'),
+  invalidateCache('cache:team::teamId:*'),
   createRole,
 )
 router.get(
@@ -223,14 +223,14 @@ router.put(
   '/:teamId/roles/:roleId',
   authenticateAccessToken,
   requireAdmin,
-  invalidateCache('cache:*:roles*'),
+  invalidateCache('cache:team::teamId:*'),
   updateRole,
 )
 router.delete(
   '/:teamId/roles/:roleId',
   authenticateAccessToken,
   requireAdmin,
-  invalidateCache('cache:*:roles*'),
+  invalidateCache('cache:team::teamId:*'),
   deleteRole,
 )
 
@@ -238,7 +238,7 @@ router.put(
   '/:teamId/members/:userId/assign-role',
   authenticateAccessToken,
   requireAdmin,
-  invalidateCache('cache:*:users*', 'cache:*:permissions*'),
+  invalidateCache('cache:team::teamId:*'),
   assignCustomRoleToUser,
 )
 

--- a/server/services/cacheService.js
+++ b/server/services/cacheService.js
@@ -130,11 +130,12 @@ class CacheService {
     try {
       if (isRedisReady()) {
         const client = getRedisClient()
-        const keys = await client.keys(pattern)
-        if (keys.length > 0) {
-          return await client.del(keys)
+        let count = 0
+        for await (const key of client.scanIterator({ MATCH: pattern, COUNT: 100 })) {
+          await client.del(key)
+          count++
         }
-        return 0
+        return count
       } else {
         return await memoryCache.delPattern(pattern)
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Redis caching layer to correctly implement the cache-aside pattern and ensures all client-side mutation requests are protected by CSRF tokens.

## Redis Fixes

1. **Aligned invalidation patterns with actual cache keys** — `invalidateCache()` patterns in `teams_routes.js` and `tasks_routes.js` now match the key format produced by `teamCacheKey`/`userCacheKey` (e.g. `cache:team::teamId:*` instead of `cache:*:announcements*`).

2. **Added missing cache invalidation** for the `GET /:teamId/:userId/tasks` cached route — task create/submit mutations now invalidate the team cache.

3. **Replaced blocking `KEYS` with `SCAN`** in `cacheService.delPattern()` using `scanIterator` for non-blocking pattern deletion.

4. **Fixed Redis/rate-limiter startup race** — `initRedis()` is now awaited before `app.listen()`, and `createRateLimiter` lazily checks Redis readiness inside `sendCommand` rather than at import time.

## CSRF Fixes

5. **Added 403 CSRF retry logic** to `apiClient.js` — mirrors the existing 401 token-refresh retry pattern.

6. **Migrated all raw `fetch()` mutation calls** across ~28 Vue components, views, stores, and services to use `fetchWithTokenRefresh()` from `apiClient.js`, which automatically attaches CSRF tokens and `credentials: 'include'`.

   Skipped files that only hit CSRF-excluded auth paths: `Login.vue`, `Register.vue`, `ForgotPassword.vue`, `ResetPassword.vue`, `VerifyEmailView.vue`.

## Verification

- Traced invalidation patterns against `teamCacheKey`/`userCacheKey` generation — patterns correctly match.
- Grepped for remaining raw `fetch()` with mutation methods — none found outside the skip list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5c65557-3015-415a-b3e4-be46ada75929?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5c65557-3015-415a-b3e4-be46ada75929&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

